### PR TITLE
Descending Dropdown

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -64,9 +64,9 @@ pygmentsUseClasses=true
         weight = 2
         latest = "2.8"
         [params.products.sensu_enterprise.versions]
-            "2.6" = ["Ubuntu/Debian", "RHEL/CentOS"]
-            "2.7" = ["Ubuntu/Debian", "RHEL/CentOS"]
             "2.8" = ["Ubuntu/Debian", "RHEL/CentOS"]
+            "2.7" = ["Ubuntu/Debian", "RHEL/CentOS"]
+            "2.6" = ["Ubuntu/Debian", "RHEL/CentOS"]
 
     [params.products.sensu_enterprise_dashboard]
         identifier = "sensu-enterprise-dashboard"

--- a/layouts/partials/productVersionDrawer.html
+++ b/layouts/partials/productVersionDrawer.html
@@ -57,9 +57,17 @@
         <!-- Grab info for the current product from global -->
         {{ $product := .Section }}
         {{ $product2 := replace $product "-" "_" }}
-        {{ $product_info := (index .Site.Params.products $product2) }} 
-        {{ range $k, $v := $product_info.versions }} 
-          <li class="hiddenItem"><a href="/{{ $product }}/{{ $k }}">{{ $k }}</a></li>
+        {{ $product_info := (index .Site.Params.products $product2) }}
+
+        <!-- There is not an easy way to reverse the versions map
+             so we need to do all this extra stuff just to do so -->
+        {{ range $k, $v := $product_info.versions }}
+          {{ $.Scratch.SetInMap "versionList" $k $k }}
+        {{ end }}
+        {{ $versionList := (default (slice) ($.Scratch.GetSortedMapValues "versionList")) }}
+        {{ range $index := seq (len $versionList) }}
+          {{ $index := sub (len $versionList) $index }}
+          <li class="hiddenItem"><a href="/{{ $product }}/{{ index $versionList $index }}">{{ index $versionList $index }}</a></li>
         {{ end }}
       </ul>
     </div>

--- a/layouts/partials/productVersionDropdown.html
+++ b/layouts/partials/productVersionDropdown.html
@@ -43,7 +43,7 @@
 
   <!-- Dropdown for versions -->
   <div id="versionButton">
-    {{ if isset .Params "version" }} 
+    {{ if isset .Params "version" }}
       {{ $display := .Params.version }}
       <a class="versionButtonTitle">{{ $display }}<i class="fa fa-chevron-down dropdownArrow" aria-hidden="true"></i></a>
     {{ else }}
@@ -56,9 +56,17 @@
         <!-- Grab info for the current product from global -->
         {{ $product := .Section }}
         {{ $product2 := replace $product "-" "_" }}
-        {{ $product_info := (index .Site.Params.products $product2) }} 
-        {{ range $k, $v := $product_info.versions }} 
-          <li class="hiddenItem"><a href="/{{ $product }}/{{ $k }}">{{ $k }}</a></li>
+        {{ $product_info := (index .Site.Params.products $product2) }}
+
+        <!-- There is not an easy way to reverse the versions map
+             so we need to do all this extra stuff just to do so -->
+        {{ range $k, $v := $product_info.versions }}
+          {{ $.Scratch.SetInMap "versionList" $k $k }}
+        {{ end }}
+        {{ $versionList := (default (slice) ($.Scratch.GetSortedMapValues "versionList")) }}
+        {{ range $index := seq (len $versionList) }}
+          {{ $index := sub (len $versionList) $index }}
+          <li class="hiddenItem"><a href="/{{ $product }}/{{ index $versionList $index }}">{{ index $versionList $index }}</a></li>
         {{ end }}
       </ul>
     </div>


### PR DESCRIPTION
Closes #78

Adds reverse ordering for version dropdowns in both the nav bar and drawer (when scaled down)
![screenshot 2018-01-22 04 12 22](https://user-images.githubusercontent.com/1707663/35251268-4bbcadea-ff8f-11e7-812a-344872498c71.png)
