### PR TITLE
Further automate and document the build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
+language: node_js
+nodejs:
+  - 9
+
 addons:
   apt:
     packages:
       - python-pygments
 
-script:
-  - bin/hugo
+before_install:
+  - export PATH="$TRAVIS_BUILD_DIR/bin:$PATH"
+
+cache: yarn
 
 deploy:
   provider: heroku

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,13 +56,15 @@ Create a new, descriptively named branch to contain your change:
 
 ```
 $ git checkout -b feature/myfeature
+$ yarn
 ```
 
 Now hack away at your awesome feature on the `feature/myfeature` branch.
 
-### 4) Testing Your Code
+### 4) Building and Testing Your Code
 
-There is not yet a standardization on how we test plugins across Sensu Community contributions. If you'd like to be part of the solution, [comment on this open Issue](https://github.com/sensu-plugins/community/issues/46). For now, please run your code on Sensu and ensure it works as expected.
+To build the site, run `yarn`. This builds the search index and compiles the static content.
+You can then run `hugo server` to view the site real-time as you develop.
 
 ### 5) Committing Code
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,6 +6,15 @@ var CONTENT_PATH_PREFIX = "content/";
 // define the grunt function for cli
 module.exports = function(grunt) {
 
+    grunt.registerTask("hugo-build", function() {
+        grunt.log.writeln("Running hugo build");
+        grunt.util.spawn({
+            cmd: "hugo",
+            args: ["build",],
+        })
+        grunt.log.ok("Successfully built site")
+    });
+
     // define the actual lunr-index task for cli
     grunt.registerTask("lunr-index", function() {
 
@@ -13,8 +22,6 @@ module.exports = function(grunt) {
 
         // makes an array of the names of all the files
         var indexPages = function() {
-            grunt.log.writeln("Inside indexPages function");
-
             var pagesIndex = [];
             // go through the folders recursively
             grunt.file.recurse(CONTENT_PATH_PREFIX, function(abspath, rootdir, subdir, filename) {
@@ -28,8 +35,6 @@ module.exports = function(grunt) {
 
         // call the appropriate process for if it's a content file (md) or html page
         var processFile = function(abspath, filename) {
-            grunt.log.writeln("Inside processFile function");
-
             var pageIndex;
             if (S(filename).endsWith(".html")) {
                 pageIndex = processHTMLFile(abspath, filename);
@@ -41,8 +46,6 @@ module.exports = function(grunt) {
 
         // process html
         var processHTMLFile = function(abspath, filename) {
-            grunt.log.writeln("Inside processHTMLFile function");
-
             // read the file contents
             var content = grunt.file.read(abspath);
             // the page name will be the filename, minus html
@@ -62,8 +65,6 @@ module.exports = function(grunt) {
 
         // process md
         var processMDFile = function(abspath, filename) {
-            grunt.log.writeln("Inside processMDFile function");
-
             // read the file contents
             var content = grunt.file.read(abspath);
             var pageIndex;
@@ -99,9 +100,9 @@ module.exports = function(grunt) {
             };
             return pageIndex;
         };
-        grunt.log.writeln("Index pages -> process file -> process based on type");
         grunt.file.write("static/js/lunr/PagesIndex.json", JSON.stringify(indexPages()));
-        grunt.log.ok("Index built");
+        grunt.log.ok("Lunr index built");
     });
-};
 
+    grunt.registerTask("default", ["lunr-index", "hugo-build",]);
+};

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ If you cloned this repository without the `--recursive` flag, you can manually p
 cd sensu-docs-site ; git submodule update --init --recursive
 ```
 
+#### Installing yarn
+
+This project uses [Yarn](https://yarnpkg.com/) to manage dependencies and the build process. For installation
+on installing yarn, [view their documentation](https://yarnpkg.com/lang/en/docs/install/).
+
 #### Installing Hugo
 
 This project requires Hugo version 0.34 or later.
@@ -52,7 +57,7 @@ Once you've installed Hugo, continue reading for viewing the site and working wi
 After installing Hugo we suggest that you test the build of the site in your local environment:
 
 ```
-hugo build
+yarn
 ```
 
 This is the same build process used by TravisCI to test changes. If this command produces any errors, please ensure you're using [the same version of Hugo documented in our wiki](https://github.com/sensu/sensu-docs-site/wiki/Hugo-version-upgrades).

--- a/package.json
+++ b/package.json
@@ -8,9 +8,14 @@
   "devDependencies": {
     "conzole": "^0.2.0",
     "grunt": "^1.0.1",
+    "husky": "^0.14.3",
     "js-yaml": "^3.9.1",
     "string": "^3.3.3",
     "toml": "^2.3.2",
     "yaml": "^0.3.0"
+  },
+  "scripts": {
+    "postinstall": "grunt",
+    "precommit": "grunt"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,6 +64,10 @@ chalk@~1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+ci-info@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
+
 cli-color@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-0.2.3.tgz#0a25ceae5a6a1602be7f77d28563c36700274e88"
@@ -270,6 +274,14 @@ hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 iconv-lite@~0.4.13:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
@@ -300,6 +312,12 @@ is-builtin-module@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
   dependencies:
     builtin-modules "^1.0.0"
+
+is-ci@^1.0.10:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
+  dependencies:
+    ci-info "^1.0.0"
 
 is-finite@^1.0.0:
   version "1.0.2"
@@ -409,6 +427,10 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
+
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -545,6 +567,10 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This centralizes the build with yarn. Now, running yarn will build the lunr index and the hugo static content. We're also leveraging Travis's built-in yarn support to build and cache dependencies.

Signed-off-by: Greg Poirier <greg.istehbest@gmail.com>