### PR TITLE
Changing the index.md layout to `single` temporarily to avoid issues with broken links from the the platform selector.

### DIFF
--- a/content/sensu-core/0.29/_index.md
+++ b/content/sensu-core/0.29/_index.md
@@ -6,7 +6,7 @@ menu: "sensu-core-0.29"
 version: "0.29"
 product: "Sensu Core"
 tags: ["sensu", "core", "sensu core", "0.29", "index"]
-layout: "product-platforms"
+layout: "single"
 ---
 
 ## Overview

--- a/content/sensu-core/1.0/_index.md
+++ b/content/sensu-core/1.0/_index.md
@@ -6,7 +6,7 @@ menu: "sensu-core-1.0"
 version: "1.0"
 product: "Sensu Core"
 tags: ["sensu", "core", "sensu core", "1.0", "frog", "index"]
-layout: "product-platforms"
+layout: "single"
 ---
 
 ## Overview

--- a/content/sensu-core/1.1/_index.md
+++ b/content/sensu-core/1.1/_index.md
@@ -6,7 +6,7 @@ menu: "sensu-core-1.1"
 version: "1.1"
 product: "Sensu Core"
 tags: ["sensu", "core", "sensu core", "1.1", "index"]
-layout: "product-platforms"
+layout: "single"
 ---
 
 ## Overview

--- a/content/sensu-core/1.2/_index.md
+++ b/content/sensu-core/1.2/_index.md
@@ -6,7 +6,7 @@ menu: "sensu-core-1.2"
 version: "1.2"
 product: "Sensu Core"
 tags: ["sensu", "core", "sensu core", "1.1", "index"]
-layout: "product-platforms"
+layout: "single"
 ---
 
 ## Overview


### PR DESCRIPTION
This should fix things until we get everything ironed out with the platform selector.