### PR TITLE
Add yarn test placeholder script

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# This is a placeholder for a future test function.
+# Needed for travis-ci.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "postinstall": "grunt",
-    "precommit": "grunt"
+    "precommit": "grunt",
+    "test": "bin/test"
   }
 }


### PR DESCRIPTION
Travis CI seems to run `yarn test` which I didn't expect. This adds a placeholder test script and the test script definition in `packages.json`.