### PR TITLE
[sensu-core] use single layout for 2.0 index page

### DIFF
--- a/content/sensu-core/2.0/_index.md
+++ b/content/sensu-core/2.0/_index.md
@@ -6,7 +6,7 @@ menu: "sensu-core-2.0"
 version: "2.0"
 product: "Sensu Core"
 tags: ["sensu", "core", "sensu core", "2.0", "index"]
-layout: "product-platforms"
+layout: "single"
 ---
 
 ## Overview


### PR DESCRIPTION
The "product-platforms" layout is currently somewhat broken and shouldn't be used right now.