### PR TITLE
Fix live reload by including footer_js partial

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -118,3 +118,5 @@ function applyTipBoxes() {
   });
 }
 </script>
+
+{{ partial "footer_js" . }}


### PR DESCRIPTION
This PR fixes the live reload functionality by adding the `footer_js` partial so we have a closing `</body>` tag, which is required for the live reload functionality, as described [here](https://gohugo.io/getting-started/usage/#livereload):

> Hugo injects the LiveReload <script> before the closing \</body> in your templates and will therefore not work if this tag is not present..

We could also just add something like this instead if for some reason we shouldn't include that partial:

```
  </body>
</html>
```