### PR TITLE
Add static.json for use with static buildpack

### DIFF
--- a/static.json
+++ b/static.json
@@ -1,4 +1,15 @@
 {
     "root": "public/",
-    "https_only": true
+    "https_only": true,
+    "rewrites": {
+        "~ ^/sensu-core/latest/?(.*)$": {
+            "url": "/sensu-core/1.2/$1"
+        },
+        "~ ^/sensu-enterprise/latest/?(.*)$": {
+            "url": "/sensu-enterprise/2.8/$1"
+        },
+        "~ ^/sensu-enterprise-dashboard/latest/?(.*)$": {
+            "url": "/sensu-enterprise-dashboard/2.11/$1"
+        }
+    }
 }

--- a/static.json
+++ b/static.json
@@ -1,0 +1,4 @@
+{
+    "root": "public/",
+    "https_only": true
+}


### PR DESCRIPTION
Depends on https://github.com/sensu/heroku-buildpack-static/commit/ca2c0f210ad371ee5359ba92b6f6b1e202615599 which adds support to pattern matching rewrites in [our fork of heroku/heroku-buildpack-static](https://github.com/sensu/heroku-buildpack-static).

Before merging this PR the buildpacks for `sensu-doc-site` app should be reconfigured to use the following, in order:

 1. heroku/nodejs                 
 2. https://github.com/sensu/heroku-buildpack-static.git

The changes described here are deployed to https://sensu-docs-staging.herokuapp.com/ so one can test that `/sensu-core/latest` redirects to `/sensu-core/1.2`, `/sensu-enterprise/latest/built-in-filters` redirects to `/sensu-enterprise/2.8/built-in-filters/` etc.