### PR TITLE
Fix miscellaneous issues with installation docs

### DIFF
--- a/content/sensu-core/0.29/installation/install-rabbitmq-on-rhel-centos.md
+++ b/content/sensu-core/0.29/installation/install-rabbitmq-on-rhel-centos.md
@@ -8,8 +8,6 @@ next: ../install-sensu-server-api
 previous: ../install-rabbitmq
 ---
 
-# Install RabbitMQ on RHEL/CentOS
-
 - [Install Erlang (the RabbitMQ runtime)](#install-erlang)
 - [Install RabbitMQ](#install-rabbitmq)
   - [Download and install RabbitMQ using `rpm` (recommended)](#download-and-install-rabbitmq-using-rpm)

--- a/content/sensu-core/0.29/installation/install-rabbitmq-on-ubuntu-debian.md
+++ b/content/sensu-core/0.29/installation/install-rabbitmq-on-ubuntu-debian.md
@@ -8,8 +8,6 @@ next: ../install-sensu-server-api
 previous: ../install-rabbitmq
 ---
 
-# Install RabbitMQ on Ubuntu/Debian
-
 - [Install Erlang (the RabbitMQ runtime)](#install-erlang)
 - [Install RabbitMQ](#install-rabbitmq)
   - [Download and install RabbitMQ using `dpkg` (recommended)](#download-and-install-rabbitmq-using-dpkg)

--- a/content/sensu-core/0.29/installation/install-rabbitmq-on-ubuntu-debian.md
+++ b/content/sensu-core/0.29/installation/install-rabbitmq-on-ubuntu-debian.md
@@ -150,7 +150,7 @@ ulimit -n 65536{{< /highlight >}}
 else run
 {{< highlight shell >}}
 systemctl edit rabbitmq-server{{< /highlight >}}
-and edit the (empty) file by inputing the following and then saving:
+and edit the (empty) file by inputting the following and then saving:
 {{< highlight shell >}}
 [Service]
 LimitNOFILE=65535{{< /highlight >}}

--- a/content/sensu-core/0.29/installation/install-rabbitmq.md
+++ b/content/sensu-core/0.29/installation/install-rabbitmq.md
@@ -9,8 +9,6 @@ menu:
     parent: installation
 ---
 
-# Install RabbitMQ
-
 [RabbitMQ][1] is a message bus that [describes itself][rabbitmq-features] as _"a
 messaging broker - an intermediary for messaging. It gives your applications a
 common platform to send and receive messages, and your messages a safe place to

--- a/content/sensu-core/0.29/installation/install-redis-on-rhel-centos.md
+++ b/content/sensu-core/0.29/installation/install-redis-on-rhel-centos.md
@@ -7,8 +7,6 @@ next: ../install-rabbitmq-on-rhel-centos
 previous: ../installation-prerequisites
 ---
 
-# Install Redis on RHEL/CentOS
-
 - [Install Redis from the EPEL repositories](#install-redis-from-the-epel-repositories)
 - [Managing the Redis service/process](#manage-the-redis-service-process)
   - [Start/stop the Redis services](#startstop-the-redis-services)

--- a/content/sensu-core/0.29/installation/install-redis-on-ubuntu-debian.md
+++ b/content/sensu-core/0.29/installation/install-redis-on-ubuntu-debian.md
@@ -8,8 +8,6 @@ next: ../install-rabbitmq-on-ubuntu-debian
 previous: ../installation-prerequisites
 ---
 
-# Install Redis on Ubuntu/Debian
-
 - [Install Redis using APT](#install-redis-using-apt)
 - [Managing the Redis service/process](#manage-the-redis-service-process)
   - [Start/stop the Redis services](#startstop-the-redis-services)

--- a/content/sensu-core/0.29/installation/install-redis.md
+++ b/content/sensu-core/0.29/installation/install-redis.md
@@ -9,8 +9,6 @@ menu:
     parent: installation
 ---
 
-# Install Redis
-
 [Redis][1] is a key-value database, which [describes itself][2] as _"an open
 source, BSD licensed, advanced key-value cache and store"_. Sensu uses Redis for
 storing persistent data. Two Sensu services, the server and API, require access

--- a/content/sensu-core/0.29/installation/install-sensu-client.md
+++ b/content/sensu-core/0.29/installation/install-sensu-client.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Install the Sensu Client
-
 Having successfully installed and configured a Sensu server and API (Sensu Core
 or Sensu Enterprise), let's now install and/or configure a Sensu client. The
 Sensu client is run on every system you need to monitor, including those running

--- a/content/sensu-core/0.29/installation/install-sensu-server-api.md
+++ b/content/sensu-core/0.29/installation/install-sensu-server-api.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Install the Sensu Server and API
-
 Once you have installed [Sensu's prerequisites][1] (RabbitMQ and/or Redis), you
 are ready to install a Sensu Server and API. The Sensu Server and API are
 available in two flavors:

--- a/content/sensu-core/0.29/installation/installation-overview.md
+++ b/content/sensu-core/0.29/installation/installation-overview.md
@@ -10,8 +10,6 @@ menu:
     parent: installation
 ---
 
-# Installation Overview
-
 ## The complete installation guide
 
 The purpose of this guide is to help provide new and experienced Sensu users

--- a/content/sensu-core/0.29/installation/installation-prerequisites.md
+++ b/content/sensu-core/0.29/installation/installation-prerequisites.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Installation Prerequisites
-
 As mentioned earlier in this guide, Sensu's [architecture][1] is one
 of its most compelling features. While this modular design makes it infinitely
 adaptable to monitor any infrastructure, it also depends on some external

--- a/content/sensu-core/0.29/installation/installation-strategies.md
+++ b/content/sensu-core/0.29/installation/installation-strategies.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Installation strategies
-
 Sensu's [architecture][1] is one of its most compelling features. It
 is flexible enough to be installed on a single system for
 development/testing/lab purposes (or small production environments), and

--- a/content/sensu-core/0.29/installation/testing-prereleases.md
+++ b/content/sensu-core/0.29/installation/testing-prereleases.md
@@ -9,8 +9,6 @@ menu:
     parent: installation
 ---
 
-# Testing Prereleases
-
 _WARNING: Sensu prereleases are your first chance to try out new
 features and bug fixes. Please be aware that you may be the first to
 discover an issue, you probably do not want to use a prerelease in

--- a/content/sensu-core/0.29/installation/upgrading.md
+++ b/content/sensu-core/0.29/installation/upgrading.md
@@ -10,8 +10,6 @@ menu:
     parent: installation
 ---
 
-# Upgrading Sensu
-
 _WARNING: Note that the biggest change in this release that may affect your
 deployment deals with our internal update to a newer Ruby. This means
 that plugins will have to be re-installed - and any old plugins will

--- a/content/sensu-core/1.0/installation/install-rabbitmq-on-rhel-centos.md
+++ b/content/sensu-core/1.0/installation/install-rabbitmq-on-rhel-centos.md
@@ -8,8 +8,6 @@ next: ../install-sensu-server-api
 previous: ../install-rabbitmq
 ---
 
-# Install RabbitMQ on RHEL/CentOS
-
 - [Install Erlang (the RabbitMQ runtime)](#install-erlang)
 - [Install RabbitMQ](#install-rabbitmq)
   - [Download and install RabbitMQ using `rpm` (recommended)](#download-and-install-rabbitmq-using-rpm)

--- a/content/sensu-core/1.0/installation/install-rabbitmq-on-ubuntu-debian.md
+++ b/content/sensu-core/1.0/installation/install-rabbitmq-on-ubuntu-debian.md
@@ -8,8 +8,6 @@ next: ../install-sensu-server-api
 previous: ../install-rabbitmq
 ---
 
-# Install RabbitMQ on Ubuntu/Debian
-
 - [Install Erlang (the RabbitMQ runtime)](#install-erlang)
 - [Install RabbitMQ](#install-rabbitmq)
   - [Download and install RabbitMQ using `dpkg` (recommended)](#download-and-install-rabbitmq-using-dpkg)

--- a/content/sensu-core/1.0/installation/install-rabbitmq-on-ubuntu-debian.md
+++ b/content/sensu-core/1.0/installation/install-rabbitmq-on-ubuntu-debian.md
@@ -150,7 +150,7 @@ ulimit -n 65536{{< /highlight >}}
 else run
 {{< highlight shell >}}
 systemctl edit rabbitmq-server{{< /highlight >}}
-and edit the (empty) file by inputing the following and then saving:
+and edit the (empty) file by inputting the following and then saving:
 {{< highlight shell >}}
 [Service]
 LimitNOFILE=65535{{< /highlight >}}

--- a/content/sensu-core/1.0/installation/install-rabbitmq.md
+++ b/content/sensu-core/1.0/installation/install-rabbitmq.md
@@ -9,8 +9,6 @@ menu:
     parent: installation
 ---
 
-# Install RabbitMQ
-
 [RabbitMQ][1] is a message bus that [describes itself][rabbitmq-features] as _"a
 messaging broker - an intermediary for messaging. It gives your applications a
 common platform to send and receive messages, and your messages a safe place to

--- a/content/sensu-core/1.0/installation/install-redis-on-rhel-centos.md
+++ b/content/sensu-core/1.0/installation/install-redis-on-rhel-centos.md
@@ -7,8 +7,6 @@ next: ../install-rabbitmq-on-rhel-centos
 previous: ../installation-prerequisites
 ---
 
-# Install Redis on RHEL/CentOS
-
 - [Install Redis from the EPEL repositories](#install-redis-from-the-epel-repositories)
 - [Managing the Redis service/process](#manage-the-redis-service-process)
   - [Start/stop the Redis services](#startstop-the-redis-services)

--- a/content/sensu-core/1.0/installation/install-redis-on-ubuntu-debian.md
+++ b/content/sensu-core/1.0/installation/install-redis-on-ubuntu-debian.md
@@ -8,8 +8,6 @@ next: ../install-rabbitmq-on-ubuntu-debian
 previous: ../installation-prerequisites
 ---
 
-# Install Redis on Ubuntu/Debian
-
 - [Install Redis using APT](#install-redis-using-apt)
 - [Managing the Redis service/process](#manage-the-redis-service-process)
   - [Start/stop the Redis services](#startstop-the-redis-services)

--- a/content/sensu-core/1.0/installation/install-redis.md
+++ b/content/sensu-core/1.0/installation/install-redis.md
@@ -9,8 +9,6 @@ menu:
     parent: installation
 ---
 
-# Install Redis
-
 [Redis][1] is a key-value database, which [describes itself][2] as _"an open
 source, BSD licensed, advanced key-value cache and store"_. Sensu uses Redis for
 storing persistent data. Two Sensu services, the server and API, require access

--- a/content/sensu-core/1.0/installation/install-sensu-client.md
+++ b/content/sensu-core/1.0/installation/install-sensu-client.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Install the Sensu Client
-
 Having successfully installed and configured a Sensu server and API (Sensu Core
 or Sensu Enterprise), let's now install and/or configure a Sensu client. The
 Sensu client is run on every system you need to monitor, including those running

--- a/content/sensu-core/1.0/installation/install-sensu-server-api.md
+++ b/content/sensu-core/1.0/installation/install-sensu-server-api.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Install the Sensu Server and API
-
 Once you have installed [Sensu's prerequisites][1] (RabbitMQ and/or Redis), you
 are ready to install a Sensu Server and API. The Sensu Server and API are
 available in two flavors:

--- a/content/sensu-core/1.0/installation/installation-overview.md
+++ b/content/sensu-core/1.0/installation/installation-overview.md
@@ -10,8 +10,6 @@ menu:
     parent: installation
 ---
 
-# Installation Overview
-
 ## The complete installation guide
 
 The purpose of this guide is to help provide new and experienced Sensu users

--- a/content/sensu-core/1.0/installation/installation-prerequisites.md
+++ b/content/sensu-core/1.0/installation/installation-prerequisites.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Installation Prerequisites
-
 As mentioned earlier in this guide, Sensu's [architecture][1] is one
 of its most compelling features. While this modular design makes it infinitely
 adaptable to monitor any infrastructure, it also depends on some external

--- a/content/sensu-core/1.0/installation/installation-strategies.md
+++ b/content/sensu-core/1.0/installation/installation-strategies.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Installation strategies
-
 Sensu's [architecture][1] is one of its most compelling features. It
 is flexible enough to be installed on a single system for
 development/testing/lab purposes (or small production environments), and

--- a/content/sensu-core/1.0/installation/testing-prereleases.md
+++ b/content/sensu-core/1.0/installation/testing-prereleases.md
@@ -9,8 +9,6 @@ menu:
     parent: installation
 ---
 
-# Testing Prereleases
-
 _WARNING: Sensu prereleases are your first chance to try out new
 features and bug fixes. Please be aware that you may be the first to
 discover an issue, you probably do not want to use a prerelease in

--- a/content/sensu-core/1.0/installation/upgrading.md
+++ b/content/sensu-core/1.0/installation/upgrading.md
@@ -10,8 +10,6 @@ menu:
     parent: installation
 ---
 
-# Upgrading Sensu
-
 _WARNING: Note that the biggest change in this release that may affect your
 deployment deals with our internal update to a newer Ruby. This means
 that plugins will have to be re-installed - and any old plugins will

--- a/content/sensu-core/1.1/installation/install-rabbitmq-on-rhel-centos.md
+++ b/content/sensu-core/1.1/installation/install-rabbitmq-on-rhel-centos.md
@@ -8,8 +8,6 @@ next: ../install-sensu-server-api
 previous: ../install-rabbitmq
 ---
 
-# Install RabbitMQ on RHEL/CentOS
-
 - [Install Erlang (the RabbitMQ runtime)](#install-erlang)
 - [Install RabbitMQ](#install-rabbitmq)
   - [Download and install RabbitMQ using `rpm` (recommended)](#download-and-install-rabbitmq-using-rpm)

--- a/content/sensu-core/1.1/installation/install-rabbitmq-on-ubuntu-debian.md
+++ b/content/sensu-core/1.1/installation/install-rabbitmq-on-ubuntu-debian.md
@@ -8,8 +8,6 @@ next: ../install-sensu-server-api
 previous: ../install-rabbitmq
 ---
 
-# Install RabbitMQ on Ubuntu/Debian
-
 - [Install Erlang (the RabbitMQ runtime)](#install-erlang)
 - [Install RabbitMQ](#install-rabbitmq)
   - [Download and install RabbitMQ using `dpkg` (recommended)](#download-and-install-rabbitmq-using-dpkg)

--- a/content/sensu-core/1.1/installation/install-rabbitmq-on-ubuntu-debian.md
+++ b/content/sensu-core/1.1/installation/install-rabbitmq-on-ubuntu-debian.md
@@ -150,7 +150,7 @@ ulimit -n 65536{{< /highlight >}}
 else run
 {{< highlight shell >}}
 systemctl edit rabbitmq-server{{< /highlight >}}
-and edit the (empty) file by inputing the following and then saving:
+and edit the (empty) file by inputting the following and then saving:
 {{< highlight shell >}}
 [Service]
 LimitNOFILE=65535{{< /highlight >}}

--- a/content/sensu-core/1.1/installation/install-rabbitmq.md
+++ b/content/sensu-core/1.1/installation/install-rabbitmq.md
@@ -9,8 +9,6 @@ menu:
     parent: installation
 ---
 
-# Install RabbitMQ
-
 [RabbitMQ][1] is a message bus that [describes itself][rabbitmq-features] as _"a
 messaging broker - an intermediary for messaging. It gives your applications a
 common platform to send and receive messages, and your messages a safe place to

--- a/content/sensu-core/1.1/installation/install-redis-on-rhel-centos.md
+++ b/content/sensu-core/1.1/installation/install-redis-on-rhel-centos.md
@@ -7,8 +7,6 @@ next: ../install-rabbitmq-on-rhel-centos
 previous: ../installation-prerequisites
 ---
 
-# Install Redis on RHEL/CentOS
-
 - [Install Redis from the EPEL repositories](#install-redis-from-the-epel-repositories)
 - [Managing the Redis service/process](#manage-the-redis-service-process)
   - [Start/stop the Redis services](#startstop-the-redis-services)

--- a/content/sensu-core/1.1/installation/install-redis-on-ubuntu-debian.md
+++ b/content/sensu-core/1.1/installation/install-redis-on-ubuntu-debian.md
@@ -8,8 +8,6 @@ next: ../install-rabbitmq-on-ubuntu-debian
 previous: ../installation-prerequisites
 ---
 
-# Install Redis on Ubuntu/Debian
-
 - [Install Redis using APT](#install-redis-using-apt)
 - [Managing the Redis service/process](#manage-the-redis-service-process)
   - [Start/stop the Redis services](#startstop-the-redis-services)

--- a/content/sensu-core/1.1/installation/install-redis.md
+++ b/content/sensu-core/1.1/installation/install-redis.md
@@ -9,8 +9,6 @@ menu:
     parent: installation
 ---
 
-# Install Redis
-
 [Redis][1] is a key-value database, which [describes itself][2] as _"an open
 source, BSD licensed, advanced key-value cache and store"_. Sensu uses Redis for
 storing persistent data. Two Sensu services, the server and API, require access

--- a/content/sensu-core/1.1/installation/install-sensu-client.md
+++ b/content/sensu-core/1.1/installation/install-sensu-client.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Install the Sensu Client
-
 Having successfully installed and configured a Sensu server and API (Sensu Core
 or Sensu Enterprise), let's now install and/or configure a Sensu client. The
 Sensu client is run on every system you need to monitor, including those running

--- a/content/sensu-core/1.1/installation/install-sensu-server-api.md
+++ b/content/sensu-core/1.1/installation/install-sensu-server-api.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Install the Sensu Server and API
-
 Once you have installed [Sensu's prerequisites][1] (RabbitMQ and/or Redis), you
 are ready to install a Sensu Server and API. The Sensu Server and API are
 available in two flavors:

--- a/content/sensu-core/1.1/installation/installation-overview.md
+++ b/content/sensu-core/1.1/installation/installation-overview.md
@@ -10,8 +10,6 @@ menu:
     parent: installation
 ---
 
-# Installation Overview
-
 ## The complete installation guide
 
 The purpose of this guide is to help provide new and experienced Sensu users

--- a/content/sensu-core/1.1/installation/installation-prerequisites.md
+++ b/content/sensu-core/1.1/installation/installation-prerequisites.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Installation Prerequisites
-
 As mentioned earlier in this guide, Sensu's [architecture][1] is one
 of its most compelling features. While this modular design makes it infinitely
 adaptable to monitor any infrastructure, it also depends on some external

--- a/content/sensu-core/1.1/installation/installation-strategies.md
+++ b/content/sensu-core/1.1/installation/installation-strategies.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Installation strategies
-
 Sensu's [architecture][1] is one of its most compelling features. It
 is flexible enough to be installed on a single system for
 development/testing/lab purposes (or small production environments), and

--- a/content/sensu-core/1.1/installation/testing-prereleases.md
+++ b/content/sensu-core/1.1/installation/testing-prereleases.md
@@ -9,8 +9,6 @@ menu:
     parent: installation
 ---
 
-# Testing Prereleases
-
 _WARNING: Sensu prereleases are your first chance to try out new
 features and bug fixes. Please be aware that you may be the first to
 discover an issue, you probably do not want to use a prerelease in

--- a/content/sensu-core/1.1/installation/upgrading.md
+++ b/content/sensu-core/1.1/installation/upgrading.md
@@ -10,8 +10,6 @@ menu:
     parent: installation
 ---
 
-# Upgrading Sensu
-
 _WARNING: Note that the biggest change in this release that may affect your
 deployment deals with our internal update to a newer Ruby. This means
 that plugins will have to be re-installed - and any old plugins will

--- a/content/sensu-core/1.2/installation/install-rabbitmq-on-rhel-centos.md
+++ b/content/sensu-core/1.2/installation/install-rabbitmq-on-rhel-centos.md
@@ -8,8 +8,6 @@ next: ../install-sensu-server-api
 previous: ../install-rabbitmq
 ---
 
-# Install RabbitMQ on RHEL/CentOS
-
 - [Install Erlang (the RabbitMQ runtime)](#install-erlang)
 - [Install RabbitMQ](#install-rabbitmq)
   - [Download and install RabbitMQ using `rpm` (recommended)](#download-and-install-rabbitmq-using-rpm)

--- a/content/sensu-core/1.2/installation/install-rabbitmq-on-ubuntu-debian.md
+++ b/content/sensu-core/1.2/installation/install-rabbitmq-on-ubuntu-debian.md
@@ -8,8 +8,6 @@ next: ../install-sensu-server-api
 previous: ../install-rabbitmq
 ---
 
-# Install RabbitMQ on Ubuntu/Debian
-
 - [Install Erlang (the RabbitMQ runtime)](#install-erlang)
 - [Install RabbitMQ](#install-rabbitmq)
   - [Download and install RabbitMQ using `dpkg` (recommended)](#download-and-install-rabbitmq-using-dpkg)

--- a/content/sensu-core/1.2/installation/install-rabbitmq-on-ubuntu-debian.md
+++ b/content/sensu-core/1.2/installation/install-rabbitmq-on-ubuntu-debian.md
@@ -150,7 +150,7 @@ ulimit -n 65536{{< /highlight >}}
 else run
 {{< highlight shell >}}
 systemctl edit rabbitmq-server{{< /highlight >}}
-and edit the (empty) file by inputing the following and then saving:
+and edit the (empty) file by inputting the following and then saving:
 {{< highlight shell >}}
 [Service]
 LimitNOFILE=65535{{< /highlight >}}

--- a/content/sensu-core/1.2/installation/install-rabbitmq.md
+++ b/content/sensu-core/1.2/installation/install-rabbitmq.md
@@ -9,8 +9,6 @@ menu:
     parent: installation
 ---
 
-# Install RabbitMQ
-
 [RabbitMQ][1] is a message bus that [describes itself][rabbitmq-features] as _"a
 messaging broker - an intermediary for messaging. It gives your applications a
 common platform to send and receive messages, and your messages a safe place to

--- a/content/sensu-core/1.2/installation/install-redis-on-rhel-centos.md
+++ b/content/sensu-core/1.2/installation/install-redis-on-rhel-centos.md
@@ -7,8 +7,6 @@ next: ../install-rabbitmq-on-rhel-centos
 previous: ../installation-prerequisites
 ---
 
-# Install Redis on RHEL/CentOS
-
 - [Install Redis from the EPEL repositories](#install-redis-from-the-epel-repositories)
 - [Managing the Redis service/process](#manage-the-redis-service-process)
   - [Start/stop the Redis services](#startstop-the-redis-services)

--- a/content/sensu-core/1.2/installation/install-redis-on-ubuntu-debian.md
+++ b/content/sensu-core/1.2/installation/install-redis-on-ubuntu-debian.md
@@ -8,8 +8,6 @@ next: ../install-rabbitmq-on-ubuntu-debian
 previous: ../installation-prerequisites
 ---
 
-# Install Redis on Ubuntu/Debian
-
 - [Install Redis using APT](#install-redis-using-apt)
 - [Managing the Redis service/process](#manage-the-redis-service-process)
   - [Start/stop the Redis services](#startstop-the-redis-services)

--- a/content/sensu-core/1.2/installation/install-redis.md
+++ b/content/sensu-core/1.2/installation/install-redis.md
@@ -9,8 +9,6 @@ menu:
     parent: installation
 ---
 
-# Install Redis
-
 [Redis][1] is a key-value database, which [describes itself][2] as _"an open
 source, BSD licensed, advanced key-value cache and store"_. Sensu uses Redis for
 storing persistent data. Two Sensu services, the server and API, require access

--- a/content/sensu-core/1.2/installation/install-sensu-client.md
+++ b/content/sensu-core/1.2/installation/install-sensu-client.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Install the Sensu Client
-
 Having successfully installed and configured a Sensu server and API (Sensu Core
 or Sensu Enterprise), let's now install and/or configure a Sensu client. The
 Sensu client is run on every system you need to monitor, including those running

--- a/content/sensu-core/1.2/installation/install-sensu-server-api.md
+++ b/content/sensu-core/1.2/installation/install-sensu-server-api.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Install the Sensu Server and API
-
 Once you have installed [Sensu's prerequisites][1] (RabbitMQ and/or Redis), you
 are ready to install a Sensu Server and API. The Sensu Server and API are
 available in two flavors:

--- a/content/sensu-core/1.2/installation/installation-overview.md
+++ b/content/sensu-core/1.2/installation/installation-overview.md
@@ -10,8 +10,6 @@ menu:
     parent: installation
 ---
 
-# Installation Overview
-
 ## The complete installation guide
 
 The purpose of this guide is to help provide new and experienced Sensu users

--- a/content/sensu-core/1.2/installation/installation-prerequisites.md
+++ b/content/sensu-core/1.2/installation/installation-prerequisites.md
@@ -4,7 +4,7 @@ description: "The complete Sensu installation guide."
 weight: 3
 product: "Sensu Core"
 version: "1.2"
-next: ../install-sensu-server-api
+next: ../install-redis
 previous: ../installation-strategies
 menu:
   sensu-core-1.2:

--- a/content/sensu-core/1.2/installation/installation-prerequisites.md
+++ b/content/sensu-core/1.2/installation/installation-prerequisites.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Installation Prerequisites
-
 As mentioned earlier in this guide, Sensu's [architecture][1] is one
 of its most compelling features. While this modular design makes it infinitely
 adaptable to monitor any infrastructure, it also depends on some external

--- a/content/sensu-core/1.2/installation/installation-strategies.md
+++ b/content/sensu-core/1.2/installation/installation-strategies.md
@@ -11,8 +11,6 @@ menu:
     parent: installation
 ---
 
-# Installation strategies
-
 Sensu's [architecture][1] is one of its most compelling features. It
 is flexible enough to be installed on a single system for
 development/testing/lab purposes (or small production environments), and

--- a/content/sensu-core/1.2/installation/testing-prereleases.md
+++ b/content/sensu-core/1.2/installation/testing-prereleases.md
@@ -9,8 +9,6 @@ menu:
     parent: installation
 ---
 
-# Testing Prereleases
-
 _WARNING: Sensu prereleases are your first chance to try out new
 features and bug fixes. Please be aware that you may be the first to
 discover an issue, you probably do not want to use a prerelease in

--- a/content/sensu-core/1.2/installation/upgrading.md
+++ b/content/sensu-core/1.2/installation/upgrading.md
@@ -10,8 +10,6 @@ menu:
     parent: installation
 ---
 
-# Upgrading Sensu
-
 _WARNING: Note that the biggest change in this release that may affect your
 deployment deals with our internal update to a newer Ruby. This means
 that plugins will have to be re-installed - and any old plugins will


### PR DESCRIPTION
* Fix a spelling error
* Remove superfluous headings which duplicate the document title
* Fix `next` nav on 1.2 prerequisites page