### PR TITLE
Refactor the Sensu 2 installation docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -52,7 +52,7 @@ pygmentsUseClasses=true
         weight = 1
         latest = "1.2"
         [params.products.sensu_core.versions]
-            "2.0" = ["Ubuntu/Debian", "RHEL/CentOS"]
+            "2.0" = ["Ubuntu/Debian", "RHEL/CentOS", "Windows"]
             "1.2" = ["Ubuntu/Debian", "RHEL/CentOS"]
             "1.1" = ["Ubuntu/Debian", "RHEL/CentOS"]
             "1.0" = ["Ubuntu/Debian", "RHEL/CentOS"]

--- a/content/sensu-core/2.0/getting-started/installation-and-configuration.md
+++ b/content/sensu-core/2.0/getting-started/installation-and-configuration.md
@@ -139,8 +139,8 @@ Coming soon.
 Verify that the services are properly running using `journalctl`.
 
 {{< highlight shell >}}
-journalctl -u sensu-backend -f
-journalctl -u sensu-agent -f
+tail -f /var/log/sensu/sensu-backend.log
+tail -f /var/log/sensu-agent.log
 {{< /highlight >}}
 
 ### Ubuntu 16.04 / CentOS 7 / RHEL 7
@@ -148,8 +148,8 @@ journalctl -u sensu-agent -f
 Verify that the services are properly running using the log files.
 
 {{< highlight shell >}}
-tail -f /var/log/sensu/sensu-backend.log
-tail -f /var/log/sensu-agent.log
+journalctl -u sensu-backend -f
+journalctl -u sensu-agent -f
 {{< /highlight >}}
 {{< platformBlockClose >}}
 

--- a/content/sensu-core/2.0/getting-started/installation-and-configuration.md
+++ b/content/sensu-core/2.0/getting-started/installation-and-configuration.md
@@ -1,5 +1,6 @@
 ---
-title: "Installation and Configuration"
+title: "Installing and configuring Sensu 2.0"
+linkTitle: "Installation and Configuration"
 description: "The Sensu Core installation guide."
 weight: 1
 version: "2.0"
@@ -9,8 +10,6 @@ menu:
   sensu-core-2.0:
     parent: getting-started
 ---
-
-## Installing and configuring Sensu 2.0
 
 The Sensu 2.0 binaries are statically linked and can be deployed to any Linux or Windows operating system.
 
@@ -22,9 +21,10 @@ The Sensu Backend (sensu-backend) is a single statically linked binary that can 
 
 The Sensu Agent (sensu-agent) is a single statically linked binary that can be deployed via packages (.deb or .rpm) or Docker image.
 
-### Linux - Package Repositories
+## Installation
 
-#### Debian / Ubuntu
+{{< platformBlock "Ubuntu/Debian" >}}
+### Ubuntu/Debian
 
 Add the Sensu nightly repository.
 
@@ -38,7 +38,10 @@ Install the packages from the Sensu nightly repository.
 sudo apt-get install sensu-backend sensu-agent
 {{< /highlight >}}
 
-#### RHEL / CentOS
+{{< platformBlockClose >}}
+
+{{< platformBlock "RHEL/CentOS" >}}
+### RHEL/CentOS
 
 Add the Sensu nightly repository.
 
@@ -51,10 +54,20 @@ Install the Sensu backend and agent packages.
 {{< highlight shell >}}
 sudo yum install sensu-backend sensu-agent
 {{< /highlight >}}
+{{< platformBlockClose >}}
 
-### Linux - Configuration
+{{< platformBlock "Windows" >}}
+### Windows
+
+Coming soon.
+{{< platformBlockClose >}}
+
+## Configuration
 
 The example config files list all of the configurable options for each service.
+
+{{< platformBlock "Ubuntu/Debian RHEL/CentOS" >}}
+### Linux
 
 #### Sensu Backend
 
@@ -82,10 +95,18 @@ by setting `backend-url`.
 backend-url:
   - "ws://127.0.0.1:8081"
 {{< /highlight >}}
+{{< platformBlockClose >}}
 
-### Linux - Starting the services
+{{< platformBlock "Windows" >}}
+### Windows
 
-#### Ubuntu 14.04 / CentOS 6 / RHEL 6
+Coming soon.
+{{< platformBlockClose >}}
+
+## Starting the services
+
+{{< platformBlock "Ubuntu/Debian RHEL/CentOS" >}}
+### Ubuntu 14.04 / CentOS 6 / RHEL 6
 
 Start the services using the sysvinit scripts.
 
@@ -94,7 +115,7 @@ sudo /etc/init.d/sensu-backend start
 sudo /etc/init.d/sensu-agent start
 {{< /highlight >}}
 
-#### Ubuntu 16.04 / CentOS 7 / RHEL 7
+### Ubuntu 16.04 / CentOS 7 / RHEL 7
 
 Start the services using systemd.
 
@@ -102,12 +123,43 @@ Start the services using systemd.
 sudo systemctl start sensu-backend
 sudo systemctl start sensu-agent
 {{< /highlight >}}
+{{< platformBlockClose >}}
 
+{{< platformBlock "Windows" >}}
 ### Windows
 
 Coming soon.
+{{< platformBlockClose >}}
 
-### Docker
+## Validating the services
+
+{{< platformBlock "Ubuntu/Debian RHEL/CentOS" >}}
+### Ubuntu 14.04 / CentOS 6 / RHEL 6
+
+Verify that the services are properly running using `journalctl`.
+
+{{< highlight shell >}}
+journalctl -u sensu-backend -f
+journalctl -u sensu-agent -f
+{{< /highlight >}}
+
+### Ubuntu 16.04 / CentOS 7 / RHEL 7
+
+Verify that the services are properly running using the log files.
+
+{{< highlight shell >}}
+tail -f /var/log/sensu/sensu-backend.log
+tail -f /var/log/sensu-agent.log
+{{< /highlight >}}
+{{< platformBlockClose >}}
+
+{{< platformBlock "Windows" >}}
+### Windows
+
+Coming soon.
+{{< platformBlockClose >}}
+
+## Docker
 
 Sensu 2.0 can be run via [Docker](https://www.docker.com/) or [rkt](https://coreos.com/rkt) using the [sensuapp/sensu](https://hub.docker.com/r/sensuapp/sensu-go/) image. When running Sensu from Docker there are a couple of things to take into consideration.
 
@@ -120,7 +172,7 @@ The backend requires 3 exposed ports and persistent storage. This example uses a
 
 We suggest, but do not require, persistent storage for sensu-agents. The Sensu Agent will cache runtime assets locally for each check. This storage should be unique per sensu-agent process.
 
-#### How To
+### How To
 
 1. Start the sensu-backend process
 
@@ -128,7 +180,6 @@ We suggest, but do not require, persistent storage for sensu-agents. The Sensu A
 docker run -v /var/lib/sensu:/var/lib/sensu -d --name sensu-backend -p 2380:2380 \
 -p 3000:3000 -p 8080:8080 -p 8081:8081 sensuapp/sensu-go:2.0.0-alpha sensu-backend start
 {{< /highlight >}}
-
 2. Start an agent
 
 In this case, we're starting an agent whose ID is the hostname with the webserver and system subscriptions. This assumes that sensu-backend is running on another host named sensu.yourdomain.com. If you are running these locally on the same system, be sure to add `--link sensu-backend` to your Docker arguments and change the backend URL `--backend-url ws://sensu-backend:8081`.

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -88,9 +88,9 @@ function togglePlatformDivs() {
   var $platformDivs = document.getElementsByClassName("platform");
   Array.prototype.forEach.call($platformDivs, function($platformDiv) {
     $platformDivId =  $platformDiv.id
-    $platformDivId = $platformDivId.replace("-", " ");
-    $platformDivId = $platformDivId.replace("_", "/");
-    if ($platformDivId != $platformCookie && $platformCookie != null) {
+    $platformDivId = $platformDivId.replace(new RegExp("-", "g"), " ");
+    $platformDivId = $platformDivId.replace(new RegExp("_", "g"), "/");
+    if (!$platformDivId.includes($platformCookie) && $platformCookie != null) {
       $platformDiv.style.display = 'none';
     } else {
       $platformDiv.style.display = 'block';


### PR DESCRIPTION
- It adds the `Windows` platform for 2.0 docs.
- It slightly modifies the behaviour of `platformBlock` so multiple platforms can be defined and if one of them match the platform in the cookie, the `div` block is displayed. I.e., `{{< platformBlock "Ubuntu/Debian RHEL/CentOS" >}}` to match Linux, so we don't have to duplicate content between these two platforms.
- Reorganize the section with the changes mentioned above.
- Add a section for the services logs.