### PR TITLE
Ignore sensu-doc-template.md when rendering

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,7 @@ canonifyURLs = true
 googleAnalytics = "UA-39138312-17"
 
 pygmentsUseClasses=true
+ignoreFiles = [ "sensu-doc-template.md" ]
 
 [["menu.sensu-core-1.0"]]
   name = "Moi API"


### PR DESCRIPTION
Prevents the following errors when running `hugo server`.

```
Building sites … ERROR 2018/03/19 13:36:55 Two or more menu items have the same name/identifier in Menu "<!-- full sensu version here, e.g., sensu-core-1.0, sensu-enterprise-2.9 -->": "Title of Your Doc/Guide".
Rename or set an unique identifier.
ERROR 2018/03/19 13:36:55 Two or more menu items have the same name/identifier in Menu "<!-- full sensu version here, e.g., sensu-core-1.0, sensu-enterprise-2.9 -->": "Title of Your Doc/Guide".
Rename or set an unique identifier.
ERROR 2018/03/19 13:36:55 Two or more menu items have the same name/identifier in Menu "<!-- full sensu version here, e.g., sensu-core-1.0, sensu-enterprise-2.9 -->": "Title of Your Doc/Guide".
Rename or set an unique identifier.
ERROR 2018/03/19 13:36:56 error processing shortcode "_internal/shortcodes/highlight.html" for page "sensu-core/1.0/files/sensu-doc-template.md": template: _internal/shortcodes/highlight.html:1:131: executing "_internal/shortcodes/highlight.html" at <0>: invalid value; expected string
ERROR 2018/03/19 13:36:56 error processing shortcode "_internal/shortcodes/highlight.html" for page "sensu-core/1.1/files/sensu-doc-template.md": template: _internal/shortcodes/highlight.html:1:131: executing "_internal/shortcodes/highlight.html" at <0>: invalid value; expected string
ERROR 2018/03/19 13:36:56 error processing shortcode "_internal/shortcodes/highlight.html" for page "sensu-core/1.2/files/sensu-doc-template.md": template: _internal/shortcodes/highlight.html:1:131: executing "_internal/shortcodes/highlight.html" at <0>: invalid value; expected string
ERROR 2018/03/19 13:36:56 error processing shortcode "_internal/shortcodes/highlight.html" for page "sensu-core/0.29/files/sensu-doc-template.md": template: _internal/shortcodes/highlight.html:1:131: executing "_internal/shortcodes/highlight.html" at <0>: invalid value; expected string
```