### PR TITLE
Mark active element in navigation

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -32,28 +32,34 @@
 
           <!-- Loop through the menus pages -->
           {{ range $y, $x := $v }}
+            
+            <!-- Determine if one the children of this menu is active so we can
+            apply the proper styling -->
+            {{ $isCurrent := ($currentNode.HasMenuCurrent $k $x) }}
 
             <!-- if the menu has a child menu -->
             {{ if .HasChildren }}
-              {{ if (in $k $version) }}
+              {{ if (in $k $version) }}         
                 {{ $niceName := replace $x.Name "-" " " }}
                 {{ $niceName := title $niceName }}
 
                 <!-- saving the menu as API breaks it in the front matter, so we need to format it here -->
                 {{ if or (eq $niceName "Api") (eq $niceName "Rbac") }}
                   {{ $niceName := upper $niceName }}
-                  <li><a class="menu-title accordion">{{ $niceName }}<span class="menu-dropdown-icon"><i class="fa fa-chevron-down" aria-hidden="true"></i></span></a>
+                  <li><a class="menu-title accordion {{ if $isCurrent }}current{{ end }}">{{ $niceName }}<span class="menu-dropdown-icon"><i class="fa fa-chevron-down" aria-hidden="true"></i></span></a>
 
                 <!-- render the title normally if not API -->
                 {{ else }}
-                  <li><a class="menu-title accordion">{{ $niceName }}<span class="menu-dropdown-icon"><i class="fa fa-chevron-down" aria-hidden="true"></i></span></a>
+                  <li><a class="menu-title accordion {{ if $isCurrent }}current{{ end }}">{{ $niceName }}<span class="menu-dropdown-icon"><i class="fa fa-chevron-down" aria-hidden="true"></i></span></a>
                 {{ end }}
-                <ul class="panel">
+                <ul class="panel" {{ if $isCurrent }}style="display: block;"{{ end }}>
 
                   <!-- Loop through the child menu's pages -->
                   {{ range .Children.ByWeight }}
                     {{ if not (eq (lower .Parent) (lower .Name)) }}
-                      <li><a class="menu-child" href="{{ .URL | absURL }}">{{ .Name }}</a></li>
+                      <!-- Determine if this children is active -->
+                      {{ $isCurrent := (eq $.Permalink (.URL | absURL | printf "%s")) }}
+                      <li><a class="menu-child {{ if $isCurrent }}current{{ end }}" href="{{ .URL | absURL }}">{{ .Name }}</a></li>
                     {{ end }}
                   {{ end }}
                 </ul>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -39,7 +39,7 @@
 
             <!-- if the menu has a child menu -->
             {{ if .HasChildren }}
-              {{ if (in $k $version) }}         
+              {{ if (in $k $version) }}
                 {{ $niceName := replace $x.Name "-" " " }}
                 {{ $niceName := title $niceName }}
 


### PR DESCRIPTION
This PR fix the navigation menu so the active page is properly identified in the menu and the parent menu is automatically open when the page is changed:

![screen shot 2018-03-19 at 3 54 12 pm](https://user-images.githubusercontent.com/4105580/37618943-2fbbe702-2b8e-11e8-92ae-4fd4dec76c4e.png)
