### PR TITLE
[Search] Ensure no null entries are added to index

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,13 +78,16 @@ module.exports = function(grunt) {
 
         // makes an array of the names of all the files
         var indexPages = function() {
-            var pagesIndex = [];
+            let pagesIndex = [];
             // go through the folders recursively
             grunt.file.recurse(CONTENT_PATH_PREFIX, function(abspath, rootdir, subdir, filename) {
                 grunt.verbose.writeln("Parse file:", abspath);
 
                 // push adds the processed file to the array of pages
-                pagesIndex.push(processFile(abspath, filename));
+                const entry = processFile(abspath, filename);
+                if (entry !== null && entry !== undefined) {
+                  pagesIndex.push(entry);
+                }
             });
             return pagesIndex;
         };

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "dependencies": {
     "grunt-env": "^0.4.4",
     "hugo-cli": "^0.5.4"
+  },
+  "engines": {
+    "node": ">= 8"
   }
 }


### PR DESCRIPTION
Search script was getting tripped up because there were null entries in the index.

Closes #279.

Signed-off-by: James Phillips <jamesdphillips@gmail.com>